### PR TITLE
feat: allow or-and-nor queries & crowdaction status filters

### DIFF
--- a/src/domain/crowdaction/enum/crowdaction.enum.ts
+++ b/src/domain/crowdaction/enum/crowdaction.enum.ts
@@ -1,7 +1,56 @@
+import { FindCriteria } from '@core/index';
+import { ICrowdAction } from '../interface';
+
 export enum CrowdActionStatusEnum {
     WAITING = 'WAITING', // Period before CrowdAction Starts
     STARTED = 'STARTED',
     ENDED = 'ENDED',
+}
+
+export function statusToFilter(status: string) {
+    const now = Date.now();
+
+    if (status == CrowdActionStatusEnum.ENDED) {
+        return { endAt: { lte: now } };
+    } else if (status == CrowdActionStatusEnum.STARTED) {
+        return { endAt: { gte: now }, startAt: { lte: now } };
+    }
+
+    return { startAt: { gte: now } };
+}
+
+export function statusesToFilter(statuses: string[]): FindCriteria<ICrowdAction> {
+    let filter = {};
+
+    if (statuses.length === 3) {
+        return filter;
+    }
+
+    const now = Date.now();
+
+    if (statuses.length == 1) {
+        filter = statusToFilter(statuses[0]);
+    } else {
+        if (statuses.includes(CrowdActionStatusEnum.STARTED) && statuses.includes(CrowdActionStatusEnum.WAITING)) {
+            filter['endAt'] = { gte: now };
+        } else if (statuses.includes(CrowdActionStatusEnum.STARTED) && statuses.includes(CrowdActionStatusEnum.ENDED)) {
+            filter['or'] = [{ startAt: { lte: now } }, { endAt: { lte: now } }];
+        } else {
+            filter['or'] = [{ endAt: { lte: now } }, { startAt: { gte: now } }];
+        }
+    }
+
+    return filter;
+}
+
+export function joinStatusToFilter(status: CrowdActionJoinStatusEnum) {
+    const now = Date.now();
+
+    if (status == CrowdActionJoinStatusEnum.OPEN) {
+        return { joinEndAt: { gte: now } };
+    }
+
+    return { joinEndAt: { lte: now } };
 }
 
 export enum CrowdActionJoinStatusEnum {

--- a/src/infrastructure/crowdaction/dto/crowdaction.dto.ts
+++ b/src/infrastructure/crowdaction/dto/crowdaction.dto.ts
@@ -127,7 +127,7 @@ export class FilterCrowdActionDto {
     readonly id?: string;
 
     @ApiProperty({ name: 'status', enum: CrowdActionStatusEnum, required: false })
-    readonly status?: CrowdActionStatusEnum;
+    readonly status?: any;
 
     @ApiProperty({ name: 'joinStatus', enum: CrowdActionJoinStatusEnum, required: false })
     readonly joinStatus?: CrowdActionJoinStatusEnum;
@@ -137,15 +137,6 @@ export class FilterCrowdActionDto {
 
     @ApiProperty({ name: 'subcategory', required: false })
     readonly subcategory?: string;
-
-    @ApiProperty({ name: 'startAt', type: Date, required: false })
-    readonly startAt?: Date;
-
-    @ApiProperty({ name: 'endAt', type: Date, required: false })
-    readonly endAt?: Date;
-
-    @ApiProperty({ name: 'joinEndAt', type: Date, required: false })
-    readonly joinEndAt?: Date;
 
     @ApiProperty({ name: 'slug', required: false })
     readonly slug?: string;

--- a/src/infrastructure/mongo/utils/mongo.utils.ts
+++ b/src/infrastructure/mongo/utils/mongo.utils.ts
@@ -4,6 +4,12 @@ import { isPlain } from '@common/utils';
 import { FindCriteria } from '@core/repository.interface';
 
 export function toMongoQuery<T>(criteria: FindCriteria<T & { id?: string; _id?: any }>): FilterQuery<T> {
+    const arrayOperators = new Map([
+        ['or', '$or'],
+        ['and', '$and'],
+        ['nor', '$nor'],
+    ]);
+
     const operators = new Map([
         ['lte', '$lte'],
         ['lt', '$lt'],
@@ -29,6 +35,12 @@ export function toMongoQuery<T>(criteria: FindCriteria<T & { id?: string; _id?: 
             if (isPlain(value)) {
                 target[key] = {};
                 stack.push([target[key], source[key]]);
+                continue;
+            }
+
+            if (arrayOperators.has(key)) {
+                const qry = Object.values(toMongoQuery(source[key] as FindCriteria<T & { id?: string; _id?: any }>));
+                target[arrayOperators.get(key)!] = qry;
                 continue;
             }
 


### PR DESCRIPTION
**Reasoning:**
Changes to `mongo.utils.ts` allows us to have queries like this: `{ or: [ startAt: { gte: now }, endAt: { lte: now } ] }`, and as you can see, this is important when "selecting" crowdactions by multiple statuses, because otherwise they can overlap.

The rest of the PR is basically changing how we can grab the correct crowdactions by status and joinStatus.